### PR TITLE
Specify UTF8 encoding in examples

### DIFF
--- a/examples/card-stack/index.html
+++ b/examples/card-stack/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
 
     <link rel="stylesheet" href="./card-stack.css">
 

--- a/examples/card-state/index.html
+++ b/examples/card-state/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
 
     <link rel="stylesheet" href="./../card-stack/card-stack.css">
     <link rel="stylesheet" href="./card-state.css">

--- a/examples/throw-confidence/index.html
+++ b/examples/throw-confidence/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
 
     <link rel="stylesheet" href="./../card-stack/card-stack.css">
     <link rel="stylesheet" href="./throw-confidence.css">


### PR DESCRIPTION
When I tried opening the example HTML files in my browser this is what I saw:
![screen shot 2014-11-07 at 16 30 48](https://cloud.githubusercontent.com/assets/632942/4960812/4e84ad52-66c7-11e4-85a3-416dca4fbc25.png)

It's because the encoding (UTF-8) wasn't specified. Here's how it looks when it's specified:
![screen shot 2014-11-07 at 16 31 12](https://cloud.githubusercontent.com/assets/632942/4960757/ba6fbdaa-66c6-11e4-83ff-0e7dd82993d4.png)

Note: I'm not using any sort of web server that would declare an encoding for me. Just the local HTML files accessed via file:///

This patch specifies the encoding on the example pages. I'm sure there are other ways of accomplishing this but here's my fix!
