### PR TITLE
Pass original hammer event

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -59,11 +59,12 @@ Card = function Card (stack, targetElement) {
 
     Card.appendToParent(targetElement);
 
-    eventEmitter.on('_panstart', function () {
+    eventEmitter.on('_panstart', function (e) {
         Card.appendToParent(targetElement);
 
         eventEmitter.trigger('dragstart', {
-            target: targetElement
+            target: targetElement,
+            origEvent: e
         });
     });
 
@@ -77,7 +78,8 @@ Card = function Card (stack, targetElement) {
         eventEmitter.trigger('dragmove', {
             target: targetElement,
             throwOutConfidence: config.throwOutConfidence(x, targetElement),
-            throwDirection: x < 0 ? Card.DIRECTION_LEFT : Card.DIRECTION_RIGHT
+            throwDirection: x < 0 ? Card.DIRECTION_LEFT : Card.DIRECTION_RIGHT,
+            origEvent: e
         });
     });
 
@@ -92,7 +94,8 @@ Card = function Card (stack, targetElement) {
         }
 
         eventEmitter.trigger('dragend', {
-            target: targetElement
+            target: targetElement,
+            origEvent: e
         });
     });
 


### PR DESCRIPTION
Useful to have original event for certain tasks.

Example: canceling native scroll event so a mobile browser doesn't scroll while you're dragging:

``` javascript
stack.on('dragmove', function (obj) {
      obj.origEvent.srcEvent.preventDefault();
});
```
