### PR TITLE
#75 readded webpack build

### DIFF
--- a/examples/card-stack/card-stack.js
+++ b/examples/card-stack/card-stack.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function () {
     var stack;
 
-    stack = gajus.Swing.Stack();
+    stack = Swing.Stack();
 
     [].forEach.call(document.querySelectorAll('.stack li'), function (targetElement) {
         stack.createCard(targetElement);

--- a/examples/card-state/card-state.js
+++ b/examples/card-state/card-state.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function () {
-    var stack = gajus.Swing.Stack(),
+    var stack = Swing.Stack(),
         cardElement = document.querySelector('.stack li');
 
     window.card = stack.createCard(cardElement);

--- a/examples/throw-confidence/throw-confidence.js
+++ b/examples/throw-confidence/throw-confidence.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', function () {
         directionBind,
         throwOutConfidenceElements;
 
-    stack = gajus.Swing.Stack();
+    stack = Swing.Stack();
     cardElement = document.querySelector('.stack li');
     throwOutConfidenceBind = document.querySelector('#throw-out-confidence-bind');
     directionBind = document.querySelector('#direction-bind');
@@ -19,10 +19,10 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     stack.on('dragmove', function (e) {
-        throwOutConfidenceElements[e.throwDirection == gajus.Swing.Card.DIRECTION_RIGHT ? 'yes' : 'no'].opacity = e.throwOutConfidence;
+        throwOutConfidenceElements[e.throwDirection == Swing.Card.DIRECTION_RIGHT ? 'yes' : 'no'].opacity = e.throwOutConfidence;
 
         throwOutConfidenceBind.innerHTML = e.throwOutConfidence.toFixed(3);
-        directionBind.innerHTML = e.throwDirection == gajus.Swing.Card.DIRECTION_RIGHT ? 'right' : 'left';
+        directionBind.innerHTML = e.throwDirection == Swing.Card.DIRECTION_RIGHT ? 'right' : 'left';
     });
 
     stack.on('dragend', function (e) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jsonfile": "^2.2.1",
     "pragmatist": "^3.0.21",
     "sinon": "^1.16.1",
-    "webpack": "^1.12.1"
+    "webpack": "^1.13.1"
   },
   "dependencies": {
     "hammerjs": "^2.0.4",
@@ -36,12 +36,14 @@
   },
   "scripts": {
     "pragmatist": "pragmatist --es5",
+    "webpack": "webpack",
     "lint": "npm run pragmatist lint",
     "test": "npm run pragmatist test",
-    "build": "npm run pragmatist build",
+    "build": "npm run pragmatist build && npm run webpack",
     "watch": "npm run pragmatist watch",
     "watch-lint": "npm run pragmatist watch-lint",
     "watch-test": "npm run pragmatist watch-test",
     "watch-build": "npm run pragmatist watch-build"
+
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
   },
   "license": "BSD-3-Clause",
   "devDependencies": {
+    "babel": "^5.8.23",
+    "babel-loader": "^5.3.2",
     "chai": "^3.2.0",
     "jsdom": "^6.3.0",
     "jsonfile": "^2.2.1",
     "pragmatist": "^3.0.21",
     "sinon": "^1.16.1",
-    "webpack": "^1.13.1"
+    "webpack": "^1.12.1"
   },
   "dependencies": {
     "hammerjs": "^2.0.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,45 @@
+var webpack,
+    filename,
+    plugins;
+
+webpack = require('webpack');
+filename = '[name].js',
+
+    plugins = [
+        new webpack.optimize.UglifyJsPlugin({minimize: true}),
+        new webpack.OldWatchingPlugin(),
+        // new webpack.NewWatchingPlugin(),
+        new webpack.optimize.DedupePlugin(),
+        new webpack.NoErrorsPlugin(),
+    ];
+
+module.exports = {
+    devtool: 'source-map',
+    context: __dirname + '/src',
+    entry: {
+        swing: './index'
+    },
+    output: {
+        path: __dirname + '/dist/browser',
+        filename: filename,
+        library: 'Swing'
+    },
+    plugins: plugins,
+    module: {
+        loaders: [
+            {
+                test: /\.js$/,
+                exclude: [
+                    /node_modules/
+                ],
+                loader: 'babel'
+            }
+        ]
+    },
+    resolve: {
+        extensions: [
+            '',
+            '.js'
+        ]
+    }
+};


### PR DESCRIPTION
See #75 The webpack.config.js is back again: copied version from 3.0.2 release, added library target to expose a global `Swing` object that's used in example code. No clue how to add the gajus namespace without globally exposing it in index generally. Added webpack build to `npm run build` script. Examples' code now conforms to sample code in Readme. Since it's in an additional build step the "binary" library shouldn't be exposed to users - they can still babel/require from src/index.js or from the gulp/babelified dist/index.js.
