### PR TITLE
Pull request

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -21,7 +21,7 @@ const Card = (stack, targetElement) => {
         currentY,
         doMove,
         eventEmitter,
-        isDraging,
+        isDragging,
         lastThrow,
         lastTranslate,
         lastX,
@@ -78,10 +78,10 @@ const Card = (stack, targetElement) => {
             currentX = 0;
             currentY = 0;
 
-            isDraging = true;
+            isDragging = true;
 
             (function animation () {
-                if (isDraging) {
+                if (isDragging) {
                     doMove();
 
                     raf(animation);
@@ -95,7 +95,7 @@ const Card = (stack, targetElement) => {
         });
 
         eventEmitter.on('panend', (e) => {
-            isDraging = false;
+            isDragging = false;
 
             const x = lastTranslate.x + e.deltaX;
             const y = lastTranslate.y + e.deltaY;

--- a/src/card.js
+++ b/src/card.js
@@ -280,6 +280,7 @@ const Card = (stack, targetElement) => {
      */
     card.on = eventEmitter.on;
     card.trigger = eventEmitter.trigger;
+    card.hammer = mc;
 
     /**
      * Throws a card into the stack from an arbitrary position.


### PR DESCRIPTION
Hi,

Thanks for the great library!

The swing cards I was working had some UX elements within them which, while interacting with those elements, should not allow the card to be moved. 

I tried several hacks but found none that really worked. In the end I exposed the Hammer Manager on the swing card itself which gave sufficient control over the panning of the card. More specifically, Hammer.js `card.hammer.get('pan').requireFailure(...)` is what I've been using.

I found one open issue #71 with a roughly similar type of issue, possibly something like this might help them as well.

I didn't update docs (yet); first wanted to check whether this is a change you're interested in at all or not, I can imagine you might want to see something like this solved differently.

Regards
