### PR TITLE
Allow the user to configure specific elements that can trigger card movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ const stack = stack = Swing.Stack(config);
 | `rotation` | Invoked in the event of `dragmove`. Determine the rotation of the element. | Rotation is equal to the proportion of horizontal and vertical offset times the `maximumRotation` constant. |
 | `maxRotation` | In effect when `rotation` is not overwritten. | 20. |
 | `transform` | Invoked in the event of `dragmove` and every time the physics solver is triggered. | Uses CSS transform to translate element position and rotation. |
+| `allowMovement` | Function that determines if movement is allowed when a movement event is fired. It has two arguments, the `event` object and a `boolean` set to true if on a touch device. | A function that returns true for all movement events. |
 
 All of the configuration parameters are optional. Refer to the source code of the [card](https://github.com/gajus/swing/blob/master/src/card.js) module to learn the parameters associated with every callback.
 

--- a/src/Card.js
+++ b/src/Card.js
@@ -155,8 +155,10 @@ const Card = (stack, targetElement) => {
     // "mousedown" event fires late on touch enabled devices, thus listening
     // to the touchstart event for touch enabled devices and mousedown otherwise.
     if (isTouchDevice()) {
-      targetElement.addEventListener('touchstart', () => {
-        eventEmitter.trigger('panstart');
+      targetElement.addEventListener('touchstart', (event) => {
+        if (config.allowMovement(event, isTouchDevice())) {
+          eventEmitter.trigger('panstart');
+        }
       });
 
       // Disable scrolling while dragging the element on the touch enabled devices.
@@ -173,7 +175,7 @@ const Card = (stack, targetElement) => {
         });
 
         global.addEventListener('touchmove', (event) => {
-          if (dragging) {
+          if (dragging && config.allowMovement(event, isTouchDevice())) {
             event.preventDefault();
           }
         });
@@ -185,11 +187,15 @@ const Card = (stack, targetElement) => {
     }
 
     mc.on('panmove', (event) => {
-      eventEmitter.trigger('panmove', event);
+      if (config.allowMovement(event, isTouchDevice())) {
+        eventEmitter.trigger('panmove', event);
+      }
     });
 
     mc.on('panend', (event) => {
-      eventEmitter.trigger('panend', event);
+      if (config.allowMovement(event, isTouchDevice())) {
+        eventEmitter.trigger('panend', event);
+      }
     });
 
     springThrowIn.addListener({
@@ -379,6 +385,9 @@ Card.makeConfig = (config = {}) => {
       Direction.LEFT,
       Direction.UP
     ],
+    allowMovement: () => {
+      return true;
+    },
     isThrowOut: Card.isThrowOut,
     maxRotation: 20,
     maxThrowOutDistance: 500,


### PR DESCRIPTION
This PR allows the user to specify a function, with parameters `event` and a `boolean` set to true if on a touch device, that will determine which elements within the card can trigger movement of the card. This is useful when you have an area within the card, such as a scrollable area, that you don't want to cause movement of the overall card.

Example usage:

```js
scope.swingOptions = {
    allowMovement: (e, isTouchDevice) => {
        // Allow movement if not on a touch device or if on a touch device and
        // the clicked element's anscestor is not the view-all-overlay
        let isViewAll = $(e.target).closest('.careers-card-view-all-overlay').length > 0;
        return !isTouchDevice || (isTouchDevice && !isViewAll);
    }
};
```

This will resolve https://github.com/gajus/swing/issues/71.