### PR TITLE
Use lint, babel and mocha versions from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "url": "https://github.com/gajus/swing"
   },
   "scripts": {
-    "build": "babel ./src --out-dir ./dist --copy-files",
-    "lint": "eslint ./src ./test",
+    "build": "node_modules/babel-cli/bin/babel ./src --out-dir ./dist --copy-files",
+    "lint": "node_modules/eslint/bin/eslint.js ./src ./test",
     "precommit": "npm run lint && npm run test",
-    "test": "mocha --compilers js:babel-register"
+    "test": "node_modules/mocha/bin/mocha --compilers js:babel-register"
   },
   "version": "3.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/gajus/swing"
   },
   "scripts": {
-    "build": "node_modules/babel-cli/bin/babel ./src --out-dir ./dist --copy-files",
+    "build": "node_modules/babel-cli/bin/babel.js ./src --out-dir ./dist --copy-files",
     "lint": "node_modules/eslint/bin/eslint.js ./src ./test",
     "precommit": "npm run lint && npm run test",
     "test": "node_modules/mocha/bin/mocha --compilers js:babel-register"


### PR DESCRIPTION
Scripts in package.json use global versions of lint, babel and mocha although they are specified as devDependencies. So you have to have those installed globally and they can be different from the version in package.json. After this PR you are ready to go after npm install and the versions mentioned in package.json are in use.