### PR TITLE
Fix lint: remove unused parameter

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -201,7 +201,7 @@ const Card = (stack, targetElement) => {
       });
     }
 
-    mc.on('panstart', (event) => {
+    mc.on('panstart', () => {
       isPanning = true;
     });
 


### PR DESCRIPTION
Pre-commit hook fails as lint errors on unused parameter.