### PR TITLE
Emitting an event in stack.DestroyCard(card)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ const card = stack.createCard(HTMLElement);
 
 | Name | Description |
 | --- | --- |
-| `stack.createCard(element)` | Creates an instance of Card and associates it with the element. |
+| `stack.createCard(element, prepend)` | Creates an instance of Card and associates it with the element. If prepend is true, the card is prepended to the stack, instead of appended [default: false]. |
 | `stack.getCard(element)` | Returns card associated with an element. |
 | `stack.on(event, listener)` | Attaches an [event listener](#events). |
 | `card.on(event, listener)` | Attaches an [event listener](#events). |

--- a/src/Card.js
+++ b/src/Card.js
@@ -296,7 +296,7 @@ const Card = (stack, targetElement) => {
       lastTranslate.coordinateX = coordinateX || 0;
       lastTranslate.coordinateY = coordinateY || 0;
 
-      Card.transform(targetElement, coordinateX, coordinateY, rotation);
+      config.transform(targetElement, coordinateX, coordinateY, rotation);
     };
 
     /**

--- a/src/Card.js
+++ b/src/Card.js
@@ -36,7 +36,7 @@ const computeDirection = (fromX, fromY, allowedDirections) => {
  * @param {HTMLElement} targetElement
  * @returns {Object} An instance of Card.
  */
-const Card = (stack, targetElement) => {
+const Card = (stack, targetElement, prepend) => {
   let card;
   let config;
   let currentX;
@@ -97,7 +97,11 @@ const Card = (stack, targetElement) => {
       ]
     });
 
-    Card.appendToParent(targetElement);
+    if (prepend) {
+      Card.prependToParent(targetElement);
+    } else {
+      Card.appendToParent(targetElement);
+    }
 
     eventEmitter.on('panstart', () => {
       Card.appendToParent(targetElement);
@@ -450,6 +454,24 @@ Card.appendToParent = (element) => {
     parentNode.removeChild(element);
     parentNode.appendChild(element);
   }
+};
+
+/**
+ * Prepend element to the parentNode.
+ *
+ * This makes the element last among the siblings.
+ *
+ * Invoked in the event of mousedown.
+ * Invoked when card is added to the stack.
+ *
+ * @param {HTMLElement} element The target element.
+ * @return {undefined}
+ */
+Card.prependToParent = function (element) {
+  const parentNode = element.parentNode;
+
+  parentNode.removeChild(element);
+  parentNode.insertBefore(element, parentNode.firstChild);
 };
 
 /**

--- a/src/Card.js
+++ b/src/Card.js
@@ -208,6 +208,7 @@ const Card = (stack, targetElement, prepend) => {
 
     mc.on('panstart', (event) => {
       isPanning = true;
+      eventEmitter.trigger('panstart', event);
     });
 
     mc.on('panmove', (event) => {

--- a/src/Card.js
+++ b/src/Card.js
@@ -461,13 +461,12 @@ Card.appendToParent = (element) => {
  *
  * This makes the element last among the siblings.
  *
- * Invoked in the event of mousedown.
- * Invoked when card is added to the stack.
+ * Invoked when card is added to the stack (when prepend is true).
  *
  * @param {HTMLElement} element The target element.
  * @return {undefined}
  */
-Card.prependToParent = function (element) {
+Card.prependToParent = (element) => {
   const parentNode = element.parentNode;
 
   parentNode.removeChild(element);

--- a/src/Card.js
+++ b/src/Card.js
@@ -34,6 +34,7 @@ const computeDirection = (fromX, fromY, allowedDirections) => {
 /**
  * @param {Stack} stack
  * @param {HTMLElement} targetElement
+ * @param {boolean} prepend
  * @returns {Object} An instance of Card.
  */
 const Card = (stack, targetElement, prepend) => {

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -55,6 +55,7 @@ const Stack = (config) => {
    * Creates an instance of Card and associates it with an element.
    *
    * @param {HTMLElement} element
+   * @param {boolean} prepend
    * @returns {Card}
    */
   stack.createCard = (element, prepend) => {

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -114,6 +114,8 @@ const Stack = (config) => {
    * @returns {null}
    */
   stack.destroyCard = (card) => {
+    eventEmitter.trigger('destroyCard', card);
+
     return _.remove(index, {
       card
     });

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -57,8 +57,8 @@ const Stack = (config) => {
    * @param {HTMLElement} element
    * @returns {Card}
    */
-  stack.createCard = (element) => {
-    const card = Card(stack, element);
+  stack.createCard = (element, prepend) => {
+    const card = Card(stack, element, prepend);
     const events = [
       'throwout',
       'throwoutend',


### PR DESCRIPTION
This is so angular2-swing can take up the event, look up the item and remove it.
Also added a panstart event emitter on Card.js for the purpose of stopping a lint unused var error.