### PR TITLE
Fix: change global to window since global does not exists in browsers.

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -186,7 +186,7 @@ const Card = (stack, targetElement, prepend) => {
           dragging = false;
         });
 
-        global.addEventListener('touchmove', (event) => {
+        window.addEventListener('touchmove', (event) => {
           if (dragging) {
             event.preventDefault();
           }


### PR DESCRIPTION
I think you work with some specific builder that understand `global` and probably transpile it for browser but for others please use `window` which seems to be the only available in browsers.

Thanks for your work! ;)