### PR TITLE
fix: manual click event trigger as the card was detached from DOM during dragging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 coverage
 dist
 node_modules
+package-lock.json
 *.log
 .*
 !.README

--- a/src/Card.js
+++ b/src/Card.js
@@ -58,6 +58,7 @@ const Card = (stack, targetElement, prepend) => {
   let throwDirectionToEventName;
   let throwOutDistance;
   let throwWhere;
+  let appendedDuringMouseDown;
 
   const construct = () => {
     card = {};
@@ -194,10 +195,16 @@ const Card = (stack, targetElement, prepend) => {
       })();
     } else {
       targetElement.addEventListener('mousedown', () => {
+        appendedDuringMouseDown = Card.appendToParent(targetElement) || appendedDuringMouseDown;
         eventEmitter.trigger('panstart');
       });
 
       targetElement.addEventListener('mouseup', () => {
+        if (appendedDuringMouseDown) {
+          targetElement.click();
+          appendedDuringMouseDown = false;
+        }
+
         if (isDraging && !isPanning) {
           eventEmitter.trigger('dragend', {
             target: targetElement
@@ -453,11 +460,14 @@ Card.appendToParent = (element) => {
   const parentNode = element.parentNode;
   const siblings = elementChildren(parentNode);
   const targetIndex = siblings.indexOf(element);
+  const appended = targetIndex + 1 !== siblings.length;
 
-  if (targetIndex + 1 !== siblings.length) {
+  if (appended) {
     parentNode.removeChild(element);
     parentNode.appendChild(element);
   }
+
+  return appended;
 };
 
 /**


### PR DESCRIPTION
## Problem

I noticed that click event is not triggered when user interact with the card for the very first time. The issues occurs only on the desktop browsers.

## Findings

Card is detached from the DOM on `mousedown` so it can be moved to front of the stack.

## Solution

Tracking whether card was detached from the DOM when card was pressed (mousedown), if so then clicked event is triggered manually.

