### PR TITLE
fix: simulating the event only when the native one was not triggered

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -160,14 +160,41 @@ const Card = (stack, targetElement, prepend) => {
       });
     });
 
+    targetElement.addEventListener('click', (event) => {
+      if (fakeClickEvent === event) {
+        return;
+      }
+
+      nativelyClickedAfterMouseUp = true;
+    });
+
+    // `setTimeout` to determine whether native click event was triggered. If so then not faking one.
+    const conditionalDispatchClick = () => {
+      return setTimeout(() => {
+        if (nativelyClickedAfterMouseUp) {
+          return;
+        }
+
+        fakeClickEvent = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window
+        });
+        targetElement.dispatchEvent(fakeClickEvent);
+      }, 0);
+    };
+
     // "mousedown" event fires late on touch enabled devices, thus listening
     // to the touchstart event for touch enabled devices and mousedown otherwise.
     if (isTouchDevice()) {
       targetElement.addEventListener('touchstart', () => {
+        nativelyClickedAfterMouseUp = false;
         eventEmitter.trigger('panstart');
       });
 
       targetElement.addEventListener('touchend', () => {
+        conditionalDispatchClick();
+
         if (isDraging && !isPanning) {
           eventEmitter.trigger('dragend', {
             target: targetElement
@@ -195,36 +222,15 @@ const Card = (stack, targetElement, prepend) => {
         });
       })();
     } else {
-      targetElement.addEventListener('click', (event) => {
-        if (fakeClickEvent === event) {
-          return;
-        }
-
-        nativelyClickedAfterMouseUp = true;
-      });
-
       targetElement.addEventListener('mousedown', () => {
         Card.appendToParent(targetElement);
 
-        // Reset here
         nativelyClickedAfterMouseUp = false;
         eventEmitter.trigger('panstart');
       });
 
       targetElement.addEventListener('mouseup', () => {
-        // `setTimeout` to determine whether native click event was triggered. If so then not faking one.
-        setTimeout(() => {
-          if (nativelyClickedAfterMouseUp) {
-            return;
-          }
-
-          fakeClickEvent = new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-            view: window
-          });
-          targetElement.dispatchEvent(fakeClickEvent);
-        }, 0);
+        conditionalDispatchClick();
 
         if (isDraging && !isPanning) {
           eventEmitter.trigger('dragend', {


### PR DESCRIPTION
This code might look scary, but it's an extra shield which prevents faking click event when native one was triggered. This solution does not target any particular browser which is good.

Related to #133

**Update**

Ready to be merged. Tested in the:

* Chrome
* Firefox
* Opera
* Edge (but actually library is broken on that browser - not my regression)

In the meantime I published the pr branch https://www.npmjs.com/package/swing-pull135